### PR TITLE
Avoid crash when `--timeout` flag is not supplied.

### DIFF
--- a/bin/up
+++ b/bin/up
@@ -126,7 +126,7 @@ if (!numWorkers || isNaN(numWorkers)) {
 
 var workerTimeout = program.timeout;
 
-if (isNaN(ms(workerTimeout))) {
+if (null != workerTimeout && isNaN(ms(workerTimeout))) {
   error('\n  Supplied worker timeout "%s" (%s) is invalid.\n'
     , program.timeout, ms(workerTimeout));
 }


### PR DESCRIPTION
Hey there,

I tryied to run `up` without specifiying a timeout and got the following error:

```
node.js:201
        throw e; // process.nextTick error, or 'error' event on first tick
          ^
TypeError: Cannot call method 'toLowerCase' of undefined
    at ms (/usr/local/lib/node_modules/up/node_modules/ms/ms.js:30:14)
    at Object.<anonymous> (/usr/local/lib/node_modules/up/bin/up:129:11)
    at Module._compile (module.js:432:26)
    at Object..js (module.js:450:10)
    at Module.load (module.js:351:31)
    at Function._load (module.js:310:12)
    at Array.0 (module.js:470:10)
    at EventEmitter._tickCallback (node.js:192:40)
```

Here's a patch.
