### PR TITLE
Add an option to write a file with the pid.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ The `up` command accepts the following options:
   - Strings like `'10s'` are accepted.
   - Defaults to `'10m'`, or `'500ms'` if `NODE_ENV` is `development`.
 
+- `-f`/`--pidfile`
+
+  - a filename to write the pid to
+  - If specified, restarts can be achieved with: "kill -s SIGUSR2 `cat pidfile.txt`"
+
 ### B) JavaScript API
 
 ```js

--- a/bin/up
+++ b/bin/up
@@ -153,8 +153,6 @@ if (program.pidfile) {
   fs.writeFile(program.pidfile, process.pid, function(err) {
     if (err) {
       error('\n  Error writing pidfile: "%s"\n', program.pidfile, err);
-    } else {
-      debug('`\033[97mkill -s SIGUSR2 `cat %s`\033[90m` to restart', program.pidfile);
     }
   });
 }

--- a/bin/up
+++ b/bin/up
@@ -34,11 +34,11 @@ var cpus = require('os').cpus().length;
 program
   .version(up.version)
   .usage('[options] <file>')
-  .option('-p, --port [port]', 'Port to listen on.', 3000)
-  .option('-f, --pidfile [pidfile]', 'Write port to pidfile')
+  .option('-p, --port <port>', 'Port to listen on.', 3000)
+  .option('-f, --pidfile <pidfile>', 'Write port to pidfile')
   .option('-w, --watch', 'Watch the module directory for changes.')
-  .option('-r, --require [file]', 'Module to require from each worker.')
-  .option('-n, --number [workers]', 'Number of workers to spawn.'
+  .option('-r, --require <file>', 'Module to require from each worker.')
+  .option('-n, --number <workers>', 'Number of workers to spawn.'
     , 'development' == process.env.NODE_ENV ? 1 : cpus)
   .option('-t, --timeout [ms]', 'Worker timeout.')
 

--- a/bin/up
+++ b/bin/up
@@ -35,6 +35,7 @@ program
   .version(up.version)
   .usage('[options] <file>')
   .option('-p, --port [port]', 'Port to listen on.', 3000)
+  .option('-f, --pidfile [pidfile]', 'Write port to pidfile')
   .option('-w, --watch', 'Watch the module directory for changes.')
   .option('-r, --require [file]', 'Module to require from each worker.')
   .option('-n, --number [workers]', 'Number of workers to spawn.'
@@ -144,6 +145,19 @@ var httpServer = http.Server().listen(program.port)
       , workerTimeout: workerTimeout
       , requires: requires
     })
+
+/**
+ * Write pidfile
+ */
+if (program.pidfile) {
+  fs.writeFile(program.pidfile, process.pid, function(err) {
+    if (err) {
+      error('\n  Error writing pidfile: "%s"\n', program.pidfile, err);
+    } else {
+      debug('`\033[97mkill -s SIGUSR2 `cat %s`\033[90m` to restart', program.pidfile);
+    }
+  });
+}
 
 /**
  * Listen on SIGUSR2 signal.


### PR DESCRIPTION
By writing the pid to a file, it's easier to automate a restart, since then it's just:

```
up --pidfile pidfile.txt lib/server.js
kill -s SIGUSR2 `cat pidfile.txt`
```
