### PR TITLE
Allow up to be invoked outside of a tty

### DIFF
--- a/bin/up
+++ b/bin/up
@@ -172,22 +172,24 @@ process.on('SIGUSR2', function () {
  * Listen on control+r
  */
 
-process.stdin.resume();
-tty.setRawMode(true);
-process.stdin.on('keypress', function (char, key) {
-  if (key.ctrl) {
-    switch (key.name) {
-      case 'c':
-        process.exit();
-        break;
+if(tty.isatty(process.stdin)) {
+  process.stdin.resume();
+  tty.setRawMode(true);
+  process.stdin.on('keypress', function (char, key) {
+    if (key.ctrl) {
+      switch (key.name) {
+        case 'c':
+          process.exit();
+          break;
 
-      case 'r':
-        debug('\033[97mctrl + r\033[90m detected - reloading');
-        srv.reload();
-        break;
+        case 'r':
+          debug('\033[97mctrl + r\033[90m detected - reloading');
+          srv.reload();
+          break;
+      }
     }
-  }
-});
+  });
+}
 
 /**
  * Watch.


### PR DESCRIPTION
If I launch this from a Makefile or a shell script:

``` shell
$ nohup up server.js > foobar &
```

it fails with error

```
AssertionError: stdin must be initialized before calling setRawMode
    at Object.setRawMode (tty.js:37:10)
    at Object.<anonymous> (/Users/shinuza/Code/up/bin/up:176:5)
    at Module._compile (module.js:441:26)
    at Object..js (module.js:459:10)
    at Module.load (module.js:348:31)
    at Function._load (module.js:308:12)
    at Array.0 (module.js:479:10)
    at EventEmitter._tickCallback (node.js:192:40)
```

this pull request fixes this by testing if stdin is a tty prior trying to `setRawMode` on it.
