### PR TITLE
allow binding to unix domain sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ The `up` command accepts the following options:
   - the port to listen on. Not required if the module already `listen`s.
   - Defaults to `3000`.
 
+- `-s`/`--socketpath`
+  - the unix domain socket path to listen on.
+  - Cannot be set if port is specified.
+
 - `-w`/`--watch`
 
   - Whether to watch for changes.

--- a/bin/up
+++ b/bin/up
@@ -35,7 +35,8 @@ var cpus = require('os').cpus().length;
 program
   .version(up.version)
   .usage('[options] <file>')
-  .option('-p, --port <port>', 'Port to listen on.', 3000)
+  .option('-p, --port <port>', 'Port to listen on.')
+  .option('-s, --socketpath <socketpath>', 'Socket path to listen on.')
   .option('-f, --pidfile <pidfile>', 'Write port to pidfile')
   .option('-w, --watch', 'Watch the module directory for changes.')
   .option('-r, --require <file>', 'Module to require from each worker.')
@@ -103,7 +104,18 @@ if (!(server instanceof http.Server)) {
 
 var port;
 
-if (null != program.port) {
+if (null != program.port && null != program.socketpath) {
+  error('\n Cannot specify both port and socketpath');
+}
+
+
+if (null == program.port) {
+  if (null == program.socketpath) {
+    port = 3000;
+  } else {
+    port = program.socketpath;
+  }
+} else {
   port = Number(program.port);
 
   if (!port || isNaN(port)) {
@@ -137,11 +149,11 @@ if (null != workerTimeout && isNaN(ms(workerTimeout))) {
  * Start!
  */
 
-debug('starting cluster with %d workers on port %d', numWorkers, port);
+debug('starting cluster with %d workers on port %s', numWorkers, port);
 debug('`\033[97mkill -s SIGUSR2 %d\033[90m` or \033[97mctrl + r\033[90m'
   + ' to load new code', process.pid);
 
-var httpServer = http.Server().listen(program.port)
+var httpServer = http.Server().listen(port)
   , srv = up(httpServer, file, {
         numWorkers: numWorkers
       , workerTimeout: workerTimeout


### PR DESCRIPTION
you can set up nginx to connect to a backend server using a unix domain socket. it would be really useful if the up binary would support listening on a unix domain socket.
