### PR TITLE
Support for sticky routing or socket.io workers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-TESTS = test/up.js
+TESTS = test/up.js test/sticky.js
 REPORTER = dot
 
 test:

--- a/lib/up.js
+++ b/lib/up.js
@@ -203,7 +203,17 @@ UpServer.prototype.nextWorker = function () {
 
 UpServer.prototype.defaultHTTP =
 UpServer.prototype.defaultWS = function (req, res, next) {
-  if (this.workers.length) {
+
+  var ioRegex = 
+    /^\/socket\.io\/[^\/]*\/(xhr-polling|htmlfile|jsonp-polling)\/([^\?]+).*/;
+  var matcher = req.url.match(ioRegex);
+
+  if(this.workers.length && matcher && matcher.length > 2) {
+    // transport = matcher[1], sid = matcher[2]
+    var sid = matcher[2];
+    var workerIndex = sid % this.workers.length;
+    next(this.workers[workerIndex].port);
+  } else if (this.workers.length) {
     next(this.nextWorker().port);
   } else {
     var self = this;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   , "devDependencies": {
         "mocha": "*"
       , "expect.js": "*"
-      , "express": "*"
+      , "express": "2.5.9"
       , "superagent": "*"
     }
 }

--- a/test/server.js
+++ b/test/server.js
@@ -20,6 +20,15 @@ app.get('/', function (req, res) {
 });
 
 /**
+ * Socket.io mock route.
+ */
+
+app.get('/socket.io/*', function (req, res) {
+  res.send({ pid: process.pid });
+});
+
+
+/**
  * Exports.
  */
 

--- a/test/sticky.js
+++ b/test/sticky.js
@@ -1,0 +1,81 @@
+
+/**
+ * Test dependencies
+ */
+
+var up = require('../lib/up')
+  , http = require('http')
+  , expect = require('expect.js')
+  , request = require('superagent')
+
+/**
+ * Suite.
+ */
+
+describe('sticky', function () {
+
+  it('should make xhr-polling socketio workers sticky', function (done) {
+    var httpServer = http.Server().listen(6009, onListen)
+      , srv = up(httpServer, __dirname + '/server', { numWorkers: 2 })
+      , url = 'http://localhost:6009/socket.io/1/xhr-polling/123?t=123';
+
+    function onListen (err) {
+      if (err) return done(err);
+      srv.on('spawn', onSpawn(srv, url, done));
+    }
+  });
+
+  it('should make htmlfile socketio workers sticky', function (done) {
+    var httpServer = http.Server().listen(6010, onListen)
+      , srv = up(httpServer, __dirname + '/server', { numWorkers: 2 })
+      , url = 'http://localhost:6009/socket.io/1/htmlfile/123?t=123';
+
+    function onListen (err) {
+      if (err) return done(err);
+      srv.on('spawn', onSpawn(srv, url, done));
+    }
+  });
+
+  it('should make jsonp-polling socketio workers sticky', function (done) {
+    var httpServer = http.Server().listen(6011, onListen)
+      , srv = up(httpServer, __dirname + '/server', { numWorkers: 2 })
+      , url = 'http://localhost:6009/socket.io/1/jsonp-polling/123?t=123';
+
+    function onListen (err) {
+      if (err) return done(err);
+      srv.on('spawn', onSpawn(srv, url, done));
+    }
+  });
+
+  function onSpawn (srv, url, done) {
+    return  function () {
+      // count workers
+      if (2 != srv.workers.length) return;
+
+      request.get(url, function (res) {
+        var pid1 = res.body.pid;
+        expect(pid1).to.be.a('number');
+
+        request.get(url, function (res) {
+          var pid2 = res.body.pid;
+          expect(pid2).to.be.a('number');
+          expect(pid2).to.equal(pid1);
+
+          request.get(url, function (res) {
+            var pid3 = res.body.pid;
+            expect(pid3).to.be.a('number');
+            expect(pid3).to.equal(pid1);
+
+            request.get(url, function (res) {
+              var pid4 = res.body.pid;
+              expect(pid4).to.be.a('number');
+              expect(pid4).to.equal(pid1);
+              done();
+            });
+          });
+        });
+      });
+    }
+  }
+
+});


### PR DESCRIPTION
I added sticky worker support for xhr-polling, jsonp-polling, and htmlfile socket.io specific routes. The stickiness is based on the socket Id in the URL (sid % num_workers = worker_index). 

I was going to just extend `up` and create a custom `distribute` routing handler but I really like the cli interface (`bin/up`) and would basically just end up forking it to copy over `up-cli`. 

Oh, I also pegged the `express` version in the `package.json` because `3.0.0alpha1` was causing the tests to fail. 
