### PR TITLE
process.platform

### DIFF
--- a/lib/up.js
+++ b/lib/up.js
@@ -301,7 +301,7 @@ Worker.prototype.shutdown = function () {
     this.emit('stateChange');
   } else if ('spawning' == this.readyState) {
     debug('killing spawning worker %s', this.pid);
-    switch (os.platform()) {
+    switch (process.platform) {
       case 'win32':
         this.proc.kill();
         break;

--- a/test/up.js
+++ b/test/up.js
@@ -10,7 +10,6 @@ var up = require('../lib/up')
   , request = require('superagent')
   , child_process = require('child_process')
   , Distributor = require('distribute')
-  , os = require('os')
 
 /**
  * Suite.
@@ -159,7 +158,7 @@ describe('up', function () {
         expect(alive(pid)).to.be(true);
 
         // kill master
-        switch (os.platform()) {
+        switch (process.platform) {
           case 'win32':
             this.proc.kill();
             break;


### PR DESCRIPTION
`os.platform()` has been changed to `process.platform` for backward compatibility, according to @TooTallNate's comment on my previous pull request.
