### PR TITLE
Add support for watching json changes and use `file` instead of `filename`

### DIFF
--- a/bin/up
+++ b/bin/up
@@ -239,7 +239,7 @@ if (undefined != program.watch) {
         p = path.join(dir, p);
         if (fs.statSync(p).isDirectory()) {
           files(p, ret);
-        } else if (p.match(/\.js$|\.coffee|\.json$/)) {
+        } else if (p.match(/\.js$|\.coffee$|\.json$/)) {
           ret.push(p);
         }
       });

--- a/bin/up
+++ b/bin/up
@@ -239,7 +239,7 @@ if (undefined != program.watch) {
         p = path.join(dir, p);
         if (fs.statSync(p).isDirectory()) {
           files(p, ret);
-        } else if (p.match(/\.js$|\.coffee$/)) {
+        } else if (p.match(/\.js$|\.coffee|\.json$/)) {
           ret.push(p);
         }
       });
@@ -259,7 +259,7 @@ if (undefined != program.watch) {
   function watch (files, fn) {
     files.forEach(function (file) {
       fs.watch(file, function (event, filename) {
-        fn(filename);
+        fn(file);
       });
     });
   };


### PR DESCRIPTION
It'd be nice to watch `json` files as well for configuration updates, so I added that.

The `filename` parameter coming back from `fs.watch` isn't supported on all
platforms. Might as well use `file` from the `forEach` loop since we have it.
