### PR TITLE
Add support for asynchronous worker startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ parameters:
 - options (`Object`)
   - `numWorkers`: (`Number`|`String`): see `--workers` above.
   - `workerTimeout`: (`Number`|`String`): see `--timeout` above.
+  - `assumeReady`: (`Boolean`): see Worker readiness below.
 
 ## Middleware
 
@@ -146,6 +147,22 @@ minutes in production. This means that if a user was uploading a file, his
 request will be processed without interruptions.
 5. As other workers bind and become available, they join the round-robin
 round.
+
+### Worker readiness
+
+By default up assume that new workers are ready for new connections,
+immediately after they have been required. This can be changed by setting
+`assumeReady` to `false`, on the `options` object when initializing
+the up server through the JavaScript API.
+
+The worker then needs to tell up, when it's ready, like this:
+```js
+var up = require('up');
+// Dummy async event
+setTimeout(function(){
+	up.ready();
+}, 1000);
+```
 
 ## Credits
 

--- a/lib/up.js
+++ b/lib/up.js
@@ -74,6 +74,7 @@ function UpServer (server, file, opts) {
   this.workerTimeout = ms(null != opts.workerTimeout
     ? opts.workerTimeout : workerTimeout);
   this.requires = opts.requires || [];
+  this.assumeReady = opts.assumeReady === undefined ? true : !!opts.assumeReady;
   if (false !== opts.workerPingInterval) {
     this.workerPingInterval = ms(opts.workerPingInterval || '1m');
   }
@@ -258,6 +259,7 @@ function Worker (server) {
   var opts = JSON.stringify({
       file: server.file
     , requires: server.requires
+    , assumeReady: server.assumeReady
     , pingInterval: server.workerPingInterval
   });
 
@@ -333,4 +335,14 @@ Worker.prototype.shutdown = function () {
     this.readyState = 'terminating';
     this.emit('stateChange');
   }
+};
+
+/**
+ * Send ready signal from within a worker
+ *
+ * @api public
+ */
+
+exports.ready = function () {
+  process.emit('message', { type: 'ready' });
 };

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -6,6 +6,20 @@
 var options = JSON.parse(process.argv[2])
   , server = require(options.file)
   , requires = options.requires
+  , assumeReady = options.assumeReady
+  , addr = null;
+
+/**
+ * Tell master, that we are and that we are ready
+ */
+
+function ready() {
+  if (addr === null) return assumeReady = true;
+  process.send({
+    type: 'addr',
+    addr: addr
+  });
+}
 
 /**
  * Run requires.
@@ -20,10 +34,10 @@ for (var i = 0, l = requires.length; i < l; i++) {
  */
 
 server.listen(function () {
-  process.send({
-      type: 'addr'
-    , addr: this.address()
-  });
+  addr = this.address();
+  if (assumeReady) {
+    ready();
+  }
 });
 
 /**
@@ -37,7 +51,10 @@ process.on('message', function (msg) {
         process.exit(0);
       }, msg.time);
       break;
-  } 
+    case 'ready':
+      ready();
+      break;
+  }
 });
 
 /**

--- a/test/ready.js
+++ b/test/ready.js
@@ -1,0 +1,8 @@
+var up = require('..');
+
+setTimeout(function(){
+  process.send({type:'test, im ready'});
+  up.ready();
+}, 0);
+
+module.exports = require('http').Server();

--- a/test/up.js
+++ b/test/up.js
@@ -180,4 +180,28 @@ describe('up', function () {
     }
   });
 
+  function testAssumeReady(done, async) {
+    var httpServer = http.Server().listen()
+      , srv = up(httpServer, __dirname + '/ready', { numWorkers: 1, assumeReady: !async })
+      , worker, ready = false;
+
+    expect(srv.spawning.length).to.be(1);
+    worker = srv.spawning[0];
+    worker.proc.on('message', function(msg){
+      if (msg.type !== 'test, im ready') return;
+      ready = true;
+    });
+    srv.on('spawn', function () {
+      expect(ready).to.be(async);
+      done();
+    });
+  }
+  it('should support asynchronous loading workers', function (done) {
+    testAssumeReady(done, true);
+  });
+  it('should support synchronous loading workers by default', function (done) {
+    testAssumeReady(done, false);
+  });
+
+
 });


### PR DESCRIPTION
This adds a new option called assumeReady (default: true)
that controls whether up should automatically add the new worker
to the pool, or if it is up to the worker to asynchronous tell
up when it is ready for to handle new requests.

Signed-off-by: Asbjørn Sloth Tønnesen ast@veridu.com
