### PR TITLE
Fix tests and revert express pinning

### DIFF
--- a/lib/up.js
+++ b/lib/up.js
@@ -327,7 +327,7 @@ Worker.prototype.shutdown = function () {
       case 'win32':
         this.proc.kill();
         break;
-      deafult:
+      default:
         this.proc.kill('SIGHUP');
     }
     this.readyState = 'terminating';

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   , "devDependencies": {
         "mocha": "*"
       , "expect.js": "*"
-      , "express": "2.5.9"
+      , "express": "*"
       , "superagent": "*"
     }
 }

--- a/test/child.js
+++ b/test/child.js
@@ -1,4 +1,4 @@
 
 var httpServer = require('http').Server()
   , up = require('../lib/up')(httpServer, __dirname + '/child-server'
-      , { workerPingInterval: '15ms' })
+      , { workerPingInterval: '15ms', numWorkers: 1 })

--- a/test/up.js
+++ b/test/up.js
@@ -160,12 +160,12 @@ describe('up', function () {
         // kill master
         switch (process.platform) {
           case 'win32':
-            this.proc.kill();
+            proc.kill();
             break;
-          deafult:
-            this.proc.kill('SIGHUP');
+          default:
+            proc.kill('SIGHUP');
         }
-        
+
         // since the ping interval is set to 15ms, we try in 30
         setTimeout(function () {
           expect(alive(pid)).to.be(false);


### PR DESCRIPTION
Fix existing tests, before adding new ones.

Also revert Express pinning because we now have support for Express 3.x
