### PR TITLE
Simple auto-respawning implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ parameters:
   - `numWorkers`: (`Number`|`String`): see `--workers` above.
   - `workerTimeout`: (`Number`|`String`): see `--timeout` above.
   - `keepAlive`: (`Boolean`): see `--keepalive` above.
+  - `minExpectedLifetime`: (`Number`|`String`): Number of ms a worker is
+    expected to live. Don't auto-respawn if a worker dies earlier. Strings
+    like `'10s'` are accepted. Defaults to `'20s'`.
 
 ## Middleware
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ The `up` command accepts the following options:
   - Strings like `'10s'` are accepted.
   - Defaults to `'10m'`, or `'500ms'` if `NODE_ENV` is `development`.
 
+- `-k`/`--keepalive`
+
+  - start a new worker after one dies unexpectedly
+
 - `-f`/`--pidfile`
 
   - a filename to write the pid to
@@ -106,6 +110,7 @@ parameters:
 - options (`Object`)
   - `numWorkers`: (`Number`|`String`): see `--workers` above.
   - `workerTimeout`: (`Number`|`String`): see `--timeout` above.
+  - `keepAlive`: (`Boolean`): see `--keepalive` above.
 
 ## Middleware
 

--- a/bin/up
+++ b/bin/up
@@ -42,6 +42,7 @@ program
   .option('-n, --number <workers>', 'Number of workers to spawn.'
     , 'development' == process.env.NODE_ENV ? 1 : cpus)
   .option('-t, --timeout [ms]', 'Worker timeout.')
+  .option('-k, --keepalive', 'Restart failed workers.')
 
 /**
  * Capture requires.
@@ -134,6 +135,12 @@ if (null != workerTimeout && isNaN(ms(workerTimeout))) {
 }
 
 /**
+ * Parse keepalive
+ */
+
+var keepAlive = program.keepalive;
+
+/**
  * Start!
  */
 
@@ -146,6 +153,7 @@ var httpServer = http.Server().listen(program.port)
         numWorkers: numWorkers
       , workerTimeout: workerTimeout
       , requires: requires
+      , keepAlive: keepAlive
     })
 
 /**

--- a/lib/up.js
+++ b/lib/up.js
@@ -176,7 +176,7 @@ UpServer.prototype.spawnWorker = function (fn) {
         if (~self.workers.indexOf(w)) {
           self.workers.splice(self.workers.indexOf(w), 1);
           self.lastIndex = -1;
-          if (self.keepAlive && (self.workers.length + self.spawning.length < this.numWorkers)) {
+          if (self.keepAlive && (self.workers.length + self.spawning.length < self.numWorkers)) {
             debug('worker %s found dead. spawning 1 new worker', w.pid);
             self.spawnWorker();
           }

--- a/lib/up.js
+++ b/lib/up.js
@@ -54,6 +54,13 @@ var workerTimeout = 'development' == env ? '500ms' : '10m';
 var numWorkers = 'development' == env ? 1 : cpus;
 
 /**
+ * Default minimum expected lifetime of a worker.
+ * If a worker dies younger, we don't respawn even if keepAlive == true.
+ * We want to prevent auto-respawning storms from overloading the system.
+ */
+var minExpectedLifetime = '20s';
+
+/**
  * UpServer factory/constructor.
  *
  * @param {String} module file
@@ -75,6 +82,7 @@ function UpServer (server, file, opts) {
     ? opts.workerTimeout : workerTimeout);
   this.requires = opts.requires || [];
   this.keepAlive = opts.keepAlive || false;
+  this.minExpectedLifetime = ms(opts.minExpectedLifetime != null ? opts.minExpectedLifetime : minExpectedLifetime);
   if (false !== opts.workerPingInterval) {
     this.workerPingInterval = ms(opts.workerPingInterval || '1m');
   }
@@ -177,8 +185,13 @@ UpServer.prototype.spawnWorker = function (fn) {
           self.workers.splice(self.workers.indexOf(w), 1);
           self.lastIndex = -1;
           if (self.keepAlive && (self.workers.length + self.spawning.length < self.numWorkers)) {
-            debug('worker %s found dead. spawning 1 new worker', w.pid);
-            self.spawnWorker();
+            if (new Date().getTime() - w.birthtime < self.minExpectedLifetime) {
+              debug('worker %s found dead at a too young age. won\'t respawn new worker', w.pid);
+            }
+            else {
+              debug('worker %s found dead. spawning 1 new worker', w.pid);
+              self.spawnWorker();
+            }
           }
         }
         break;
@@ -247,6 +260,7 @@ function Worker (server) {
   this.proc.on('message', this.onMessage.bind(this));
   this.proc.on('exit', this.onExit.bind(this));
   this.pid = this.proc.pid;
+  this.birthtime = new Date().getTime();
   debug('worker %s created', this.pid);
 }
 

--- a/lib/up.js
+++ b/lib/up.js
@@ -74,6 +74,7 @@ function UpServer (server, file, opts) {
   this.workerTimeout = ms(null != opts.workerTimeout
     ? opts.workerTimeout : workerTimeout);
   this.requires = opts.requires || [];
+  this.keepAlive = opts.keepAlive || false;
   if (false !== opts.workerPingInterval) {
     this.workerPingInterval = ms(opts.workerPingInterval || '1m');
   }
@@ -175,7 +176,10 @@ UpServer.prototype.spawnWorker = function (fn) {
         if (~self.workers.indexOf(w)) {
           self.workers.splice(self.workers.indexOf(w), 1);
           self.lastIndex = -1;
-          // @TODO: auto-add workers ?
+          if (self.keepAlive && (self.workers.length + self.spawning.length < this.numWorkers)) {
+            debug('worker %s found dead. spawning 1 new worker', w.pid);
+            self.spawnWorker();
+          }
         }
         break;
     }

--- a/lib/up.js
+++ b/lib/up.js
@@ -169,7 +169,7 @@ UpServer.prototype.spawnWorker = function (fn) {
 
       case 'terminating':
       case 'terminated':
-        if (~self.spawning.indexOf(self.spawning.indexOf(w))) {
+        if (~self.spawning.indexOf(w)) {
           self.spawning.splice(self.spawning.indexOf(w), 1);
         }
         if (~self.workers.indexOf(w)) {


### PR DESCRIPTION
- Enable with the `keepAlive` (or `--keepalive` in cli) option.
- Does not respawn if a worker dies too quickly to prevent auto-respawning storm.
- `reload()` brings the number of workers back to `numWorkers`.
