### PR TITLE
Ensure all workers are gone before spawning if the timeout is zero.

### DIFF
--- a/lib/up.js
+++ b/lib/up.js
@@ -109,9 +109,6 @@ UpServer.prototype.reload = function (fn) {
   }
 
   if (this.workerTimeout > 0) {
-    // If workerTimeout is greater than zero, we spawn new workers before
-    // shutting down the current ones.
-
     // snapshot what workers we'll shut down
     var reload = [].concat(this.workers)
       , self = this
@@ -130,18 +127,14 @@ UpServer.prototype.reload = function (fn) {
       }
     });
   } else {
-    // If workerTimeout is zero, we ensure that all workers are shut down
-    // before spawning new ones.
-
     debug('removing old workers');
     for (var i = 0, l = this.workers.length; i < l; i++) {
       this.workers[i].shutdown();
     }
 
-    var listener
-      , self = this
+    var self = this
 
-    this.on('terminate', listener = function () {
+    this.on('terminate', function listener() {
       if (self.workers.length == 0 && self.spawning == 0) {
         debug('all workers removed. spawning %d new workers', self.numWorkers);
         self.spawnWorkers(self.numWorkers);

--- a/lib/up.js
+++ b/lib/up.js
@@ -108,23 +108,52 @@ UpServer.prototype.reload = function (fn) {
     this.spawning[i].shutdown();
   }
 
-  // snapshot what workers we'll shut down
-  var reload = [].concat(this.workers)
-    , self = this
+  if (this.workerTimeout > 0) {
+    // If workerTimeout is greater than zero, we spawn new workers before
+    // shutting down the current ones.
 
-  debug('reloading - spawning %d new workers', this.numWorkers);
-  this.spawnWorkers(this.numWorkers);
+    // snapshot what workers we'll shut down
+    var reload = [].concat(this.workers)
+      , self = this
 
-  this.once('spawn', function (worker) {
-    debug('worker %s spawned - removing old workers', worker.pid);
-    self.emit('reload');
-    fn && fn();
+    debug('reloading - spawning %d new workers', this.numWorkers);
+    this.spawnWorkers(this.numWorkers);
 
-    // shut down old workers
-    for (var i = 0, l = reload.length; i < l; i++) {
-      reload[i].shutdown();
+    this.once('spawn', function (worker) {
+      debug('worker %s spawned - removing old workers', worker.pid);
+      self.emit('reload');
+      fn && fn();
+
+      // shut down old workers
+      for (var i = 0, l = reload.length; i < l; i++) {
+        reload[i].shutdown();
+      }
+    });
+  } else {
+    // If workerTimeout is zero, we ensure that all workers are shut down
+    // before spawning new ones.
+
+    debug('removing old workers');
+    for (var i = 0, l = this.workers.length; i < l; i++) {
+      this.workers[i].shutdown();
     }
-  });
+
+    var listener
+      , self = this
+
+    this.on('terminate', listener = function () {
+      if (self.workers.length == 0 && self.spawning == 0) {
+        debug('all workers removed. spawning %d new workers', self.numWorkers);
+        self.spawnWorkers(self.numWorkers);
+        self.removeListener('terminate', listener);
+
+        this.once('spawn', function() {
+          self.emit('reload');
+          fn && fn();
+        })
+      }
+    })
+  }
 
   return this;
 };
@@ -164,9 +193,8 @@ UpServer.prototype.spawnWorker = function (fn) {
         self.emit('spawn', w);
         break;
 
-      case 'terminating':
       case 'terminated':
-        if (~self.spawning.indexOf(self.spawning.indexOf(w))) {
+        if (~self.spawning.indexOf(w)) {
           self.spawning.splice(self.spawning.indexOf(w), 1);
         }
         if (~self.workers.indexOf(w)) {
@@ -174,6 +202,7 @@ UpServer.prototype.spawnWorker = function (fn) {
           self.lastIndex = -1;
           // @TODO: auto-add workers ?
         }
+        self.emit('terminate', w)
         break;
     }
   });


### PR DESCRIPTION
Sometimes it is useful to have all old workers gone before spawning new ones. This patch adds support for that, when `workerTimeout` is set to 0.
