### PR TITLE
Working Directory, Signals, Respawn and Internals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ when files change in the working directory.
 - Easy-to-use CLI interface for development with automatic reloading
   upon file changes.
 - Gracefully handles reloads with syntax errors during development.
+- Auto-spawns new workers upon unexepected exits without cyclical respawn disasters.
 - Built on [distribute](http://github.com/learnboost/distribute).
 
 ## Setup
@@ -89,6 +90,17 @@ The `up` command accepts the following options:
   - A value to give `process.title`.
   - Defaults to `up`.
   - The value will be appended with `master` or `worker` (e.g "up master", "up worker").
+
+- `u`/`--uptime`
+
+  - The mininum update a worker process should live for in order to be replaced by another worker. It will otherwise be considered a cyclical restart.
+  - Defaults to 5000 ms.
+
+- `-d`/`--directory`
+
+  - The working directory to change into prior to starting the master process.
+  - Defaults to the current working directory.
+  - Note that this will effect the pathing used for `--pidfile` and `<file>`.
 
 ### B) JavaScript API
 
@@ -170,6 +182,10 @@ setTimeout(function(){
 	up.ready();
 }, 1000);
 ```
+
+### Signals
+
+Comming soon...
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The `up` command accepts the following options:
   - The mininum update a worker process should live for in order to be replaced by another worker. It will otherwise be considered a cyclical restart.
   - Defaults to 5000 ms.
 
-- `-d`/`--directory`
+- `-C`/`--cwd`
 
   - The working directory to change into prior to starting the master process.
   - Defaults to the current working directory.
@@ -182,10 +182,6 @@ setTimeout(function(){
 	up.ready();
 }, 1000);
 ```
-
-### Signals
-
-Comming soon...
 
 ## Credits
 

--- a/bin/up
+++ b/bin/up
@@ -213,16 +213,6 @@ signal('SIGQUIT', 'shutdown workers and master', function () {
   });
 });
 
-
-/**
- * Shutdown workers gracefully, but keep the master up.
- */
-
-signal('SIGWINCH', 'shutdown workers', function () {
-  srv.shutdown();
-});
-
-
 /**
  * Hard shutdown workers and master.
  */

--- a/bin/up
+++ b/bin/up
@@ -44,7 +44,7 @@ program
     , 'development' == process.env.NODE_ENV ? 1 : cpus)
   .option('-t, --timeout [ms]', 'Worker timeout.')
   .option('-u, --uptime [ms]', 'Minimum worker uptime for exit replacement.')
-  .option('-d, --directory <directory>', 'Working dictory', path.resolve);
+  .option('-C, --cwd <directory>', 'Change working directory.', path.resolve);
 
 /**
  * Capture requires.

--- a/bin/up
+++ b/bin/up
@@ -258,7 +258,9 @@ if (tty.isatty(0)) {
     var key = b.toString('utf8');
     switch (key) {
       case '\u0003': // Ctrl+C
-        srv.exit();
+        srv.exit(function () {
+          process.exit(0);
+        });
         break;
 
       case '\u0012': // Ctrl+R

--- a/bin/up
+++ b/bin/up
@@ -43,6 +43,8 @@ program
   .option('-n, --number <workers>', 'Number of workers to spawn.'
     , 'development' == process.env.NODE_ENV ? 1 : cpus)
   .option('-t, --timeout [ms]', 'Worker timeout.')
+  .option('-u, --uptime [ms]', 'Minimum worker uptime for exit replacement.')
+  .option('-d, --directory <directory>', 'Working dictory', path.resolve);
 
 /**
  * Capture requires.
@@ -59,6 +61,20 @@ program.on('require', function (file) {
  */
 
 program.parse(process.argv);
+
+/**
+ * Change to the optional working directory.
+ */
+
+if (program.directory) {
+  try {
+    process.chdir(program.directory);
+    debug('working directory set %s', program.directory);
+  } catch (e) {
+    error('\n  Error changing working directory to "%s".\n  %s\n'
+      , program.directory, e.stack);
+  }
+}
 
 /**
  * Helper function to exit with an error.
@@ -148,11 +164,13 @@ var httpServer = http.Server().listen(program.port)
       , workerTimeout: workerTimeout
       , requires: requires
       , title: program.title
+      , uptimeThreshold: program.uptime
     })
 
 /**
  * Write pidfile
  */
+
 if (program.pidfile) {
   fs.writeFile(program.pidfile, process.pid, function(err) {
     if (err) {
@@ -162,13 +180,70 @@ if (program.pidfile) {
 }
 
 /**
- * Listen on SIGUSR2 signal.
+ * Reload load workers gracefully.
  */
 
-process.on('SIGUSR2', function () {
-  debug('\033[97mSIGUSR2\033[90m signal detected - reloading');
+signal('SIGUSR2', 'reload', function () {
   srv.reload();
 });
+
+/**
+ * Spawn a new worker.
+ */
+
+signal('SIGTTIN', 'add worker', function () {
+  srv.spawnWorker();
+});
+
+/**
+ * Remove a worker.
+ */
+
+signal('SIGTTOU', 'remove worker', function () {
+  srv.removeWorker();
+});
+
+/**
+ * Shutdown workers and master gracefully.
+ */
+
+signal('SIGQUIT', 'shutdown workers and master', function () {
+  srv.shutdown(function () {
+    process.exit(0);
+  });
+});
+
+
+/**
+ * Shutdown workers gracefully, but keep the master up.
+ */
+
+signal('SIGWINCH', 'shutdown workers', function () {
+  srv.shutdown();
+});
+
+
+/**
+ * Hard shutdown workers and master.
+ */
+
+signal('SIGTERM', 'hard shutdown master and workers', function () {
+  srv.exit(function () {
+    process.exit(0);
+  });
+});
+
+/**
+ * Helper function for signals.
+ */
+
+function signal (sig, msg, fn) {
+  process.on(sig, function() {
+    debug('\033[97m' + sig +'\033[90m signal detected - ' + msg);
+    fn && fn.apply(process, arguments);
+  });
+}
+
 
 /**
  * Use the preferred "raw mode" API depending on the node version.
@@ -193,7 +268,7 @@ if (tty.isatty(0)) {
     var key = b.toString('utf8');
     switch (key) {
       case '\u0003': // Ctrl+C
-        process.exit();
+        srv.exit();
         break;
 
       case '\u0012': // Ctrl+R

--- a/bin/up
+++ b/bin/up
@@ -180,6 +180,14 @@ if (program.pidfile) {
 }
 
 /**
+ * Shutdown workers gracefully but keep the master going.
+ */
+
+signal('SIGUSR1', 'shutdown workers', function () {
+  srv.shutdownWorkers();
+});
+
+/**
  * Reload load workers gracefully.
  */
 

--- a/lib/up.js
+++ b/lib/up.js
@@ -54,6 +54,12 @@ var workerTimeout = 'development' == env ? '500ms' : '10m';
 var numWorkers = 'development' == env ? 1 : cpus;
 
 /**
+ * Default worker uptime threshold.
+ */
+
+var uptimeThreshold = '5s';
+
+/**
  * UpServer factory/constructor.
  *
  * @param {String} module file
@@ -82,7 +88,7 @@ function UpServer (server, file, opts) {
   this.workers = [];
   this.spawning = [];
   this.lastIndex = -1;
-  this.uptimeThreshold = opts.uptimeThreshold || 5000;
+  this.uptimeThreshold = ms(opts.uptimeThreshold || uptimeThreshold);
 
   if (opts.title) {
     this.title = opts.title;

--- a/lib/up.js
+++ b/lib/up.js
@@ -82,21 +82,96 @@ function UpServer (server, file, opts) {
   this.workers = [];
   this.spawning = [];
   this.lastIndex = -1;
+  this.uptimeThreshold = opts.uptimeThreshold || 5000;
 
   if (opts.title) {
     this.title = opts.title;
     process.title = this.title + ' master';
   }
 
+  // bind event handlers
+  this.on('terminate', this.onTerminate);
+
   // setup workers
   this.spawnWorkers(this.numWorkers);
-};
+}
 
 /**
  * Inherits from EventEmitter.
  */
 
 UpServer.prototype.__proto__ = Distributor.prototype;
+
+/**
+ * Spawns a new worker when the worker has been terminated and
+ * has lived longer that the minimum uptime.
+ *
+ * @param {Worker} worker
+ * @api private
+ */
+
+UpServer.prototype.onTerminate = function(worker) {
+  var uptime = new Date() - worker.startup;
+  if (worker.exitCode === 1) {
+    if (uptime > this.uptimeThreshold) {
+      debug('spawning new worker to replace worker %d', worker.pid);
+      this.spawnWorker();
+    } else {
+      debug('cyclic restart detected -- no more workers will be spawned.');
+    }
+  }
+};
+
+/**
+ * Shutsdown either the workers being passed in or the
+ * currently spawned workers.
+ *
+ * @param {Array} workers
+ * @return {UpServer} for chaining
+ * @api public
+ */
+
+UpServer.prototype.shutdownWorkers = function (workers) {
+  workers = Array.isArray(workers) ? workers : this.workers;
+
+  for (var i = 0, l = workers.length; i < l; i++) {
+    workers[i].shutdown();
+  }
+
+  return this;
+};
+
+/**
+ * Shutdown master.
+ *
+ * @param {Function} callback
+ * @return {UpServer} for chaining
+ */
+
+UpServer.prototype.shutdown = function (fn) {
+  if (this.shuttingdown) {
+    debug('shutdown in process - ignoring shutdown');
+    return this;
+  }
+  this.shutdownWorkers();
+  fn && fn();
+  return this;
+};
+
+/**
+ * Hard shutdown, kills all worker processes and then exits.
+ */
+
+UpServer.prototype.exit = function(fn) {
+  var all = [].concat(this.spawning).concat(this.workers);
+  fn = fn || process.exit;
+  all.forEach(function(worker) {
+    debug('killing worker %d', worker.pid);
+    worker.exit(0);
+  });
+  fn();
+};
+
 
 /**
  * Reloads the workers.
@@ -112,50 +187,20 @@ UpServer.prototype.reload = function (fn) {
     return this;
   }
 
-  // remove all workers in the spawning state
-  for (var i = 0, l = this.spawning.length; i < l; i++) {
-    this.spawning[i].shutdown();
-  }
+  var old = [].concat(this.workers)
+    , self = this;
 
-  if (this.workerTimeout > 0) {
-    // snapshot what workers we'll shut down
-    var reload = [].concat(this.workers)
-      , self = this
+  debug('reloading - spawning %d new workers', this.numWorkers);
+  this.spawnWorkers(this.numWorkers);
 
-    debug('reloading - spawning %d new workers', this.numWorkers);
-    this.spawnWorkers(this.numWorkers);
+  this.once('spawn', function (worker) {
+    debug('worker %s spawned - removing old workers', worker.pid);
+    self.emit('reload');
+    fn && fn();
 
-    this.once('spawn', function (worker) {
-      debug('worker %s spawned - removing old workers', worker.pid);
-      self.emit('reload');
-      fn && fn();
-
-      // shut down old workers
-      for (var i = 0, l = reload.length; i < l; i++) {
-        reload[i].shutdown();
-      }
-    });
-  } else {
-    debug('removing old workers');
-    for (var i = 0, l = this.workers.length; i < l; i++) {
-      this.workers[i].shutdown();
-    }
-
-    var self = this
-
-    this.on('terminate', function listener() {
-      if (self.workers.length == 0 && self.spawning == 0) {
-        debug('all workers removed. spawning %d new workers', self.numWorkers);
-        self.spawnWorkers(self.numWorkers);
-        self.removeListener('terminate', listener);
-
-        this.once('spawn', function() {
-          self.emit('reload');
-          fn && fn();
-        })
-      }
-    })
-  }
+    // shutdown old workers
+    self.shutdownWorkers(old);
+  });
 
   return this;
 };
@@ -171,6 +216,26 @@ UpServer.prototype.spawnWorkers = function (n) {
   debug('spawning %d workers from master %d', n, process.pid);
   for (var i = 0, l = n; i < l; i++) {
     this.spawnWorker();
+  }
+};
+
+/**
+ * Removes a worker for the round.
+ *
+ * @api public
+ */
+
+UpServer.prototype.removeWorker = function(fn) {
+  debug('removing worker from master %d', process.pid);
+  if (this.workers.length > 1) {
+    for (var i = 0, l = this.workers.length; i < l; i++) {
+      if (this.workers[i].readyState === 'spawned') {
+        this.workers[i].shutdown();
+        break;
+      }
+    }
+  } else {
+    debug('only 1 worker left -- ignoring remove');
   }
 };
 
@@ -202,7 +267,6 @@ UpServer.prototype.spawnWorker = function (fn) {
         if (~self.workers.indexOf(w)) {
           self.workers.splice(self.workers.indexOf(w), 1);
           self.lastIndex = -1;
-          // @TODO: auto-add workers ?
         }
         self.emit('terminate', w)
         break;
@@ -260,6 +324,7 @@ UpServer.prototype.defaultWS = function (req, res, next) {
 function Worker (server) {
   this.server = server;
   this.readyState = 'spawning';
+  this.startup = new Date();
 
   var opts = JSON.stringify({
       file: server.file
@@ -289,12 +354,32 @@ Worker.prototype.__proto__ = EventEmitter.prototype;
  * @api private
  */
 
-Worker.prototype.onExit = function () {
-  debug('worker %s exited '
-    + ('terminating' != this.readyState ? 'unexpectedly': ''), this.pid);
+Worker.prototype.onExit = function (code, signal) {
+  debug('worker %s exited ' + (code === 1 ? 'unexpectedly': ''), this.pid);
   this.readyState = 'terminated';
+  this.exitCode = code;
   this.emit('stateChange');
 };
+
+/**
+ * Cross platform worker kill.
+ *
+ * @api private
+ */
+
+Worker.prototype.exit = function() {
+  // set readyState so exit handlers do not attempt to spawn again
+  this.readyState = 'terminated';
+  switch (process.platform) {
+      case 'win32':
+        this.proc.kill();
+        break;
+      default:
+        this.proc.kill('SIGHUP');
+    }
+};
+
+
 
 /**
  * Handles an incoming message from the worker.
@@ -331,13 +416,7 @@ Worker.prototype.shutdown = function () {
     this.emit('stateChange');
   } else if ('spawning' == this.readyState) {
     debug('killing spawning worker %s', this.pid);
-    switch (process.platform) {
-      case 'win32':
-        this.proc.kill();
-        break;
-      default:
-        this.proc.kill('SIGHUP');
-    }
+    this.kill();
     this.readyState = 'terminating';
     this.emit('stateChange');
   }

--- a/test/server.js
+++ b/test/server.js
@@ -27,6 +27,17 @@ app.get('/socket.io/*', function (req, res) {
   res.send({ pid: process.pid });
 });
 
+/**
+ * Simulate an error that does not breach uptime threshold.
+ */
+
+app.get('/throw', function (req, res) {
+	setTimeout(function () {
+		throw new Error('ahhhh');
+	}, 10);
+	res.send({ ok: 'ok' });
+});
+
 
 /**
  * Exports.


### PR DESCRIPTION
Sorry for the single pull request, committed too much at once... 
### Working Directory

This adds the ability for the CLI to accept the option `-d/--directory` to change the location of process.chdir.
### Signals

This adds the following signals for the CLI to bind to. Right now they are bound no matter what, but perhaps there should be an option `-s/--signals` for opting out.

```
- `SIGTTIN`: Spawn a new worker to the round.
- `SIGTTOU`: Remove a worker from the round.
- `SIGTERM`: Hard shutdown of master and workers.
- `SIGQUIT`: Gracefully shutdown workers and the master.
- `SIGUSR1`: Gracefully shutdown workers but keep the master up.
```
### Respawning

This adds the feature of spawning a new worker after an existing one exits. There are two conditions that must be satisfied in order for this to happen.

```
- The worker needs to have exited unexpectedly (e.g. worker.exitCode === 1). This is accomplished simply by checking the `exit` from exit event emitted by a child_process.
- The worker needs to have an uptime greater than the `uptimeThreshold` which can be set through the CLI options via `-u/--uptime`.
```
### API and Internal Changes

To add some of the features above, I changed `UpServer` and `Worker` a good bit. Previously `UpServer#reload` was the only hook into spawning and shutting down workers. I have added:

```
- UpServer#shutdownWorkers();
- UpSerever#shutdown();
- UpServer#exit();
- UpServer#removeWorker();
- Worker#exit();
```

`UpServer.reload()` is alot slimmer now, these changes may be debatable. Before, [if there was a workerTimeout set](https://github.com/LearnBoost/up/blob/master/lib/up.js#L120), new workers were spawned and upon the first worker being spawned, the old workers were `shutdown`. However, [if there was no workerTimeout set](https://github.com/LearnBoost/up/blob/master/lib/up.js#L140), the workers were shutdown and after the last worker died, the new workers were spawned. Unless I was looking at it wrong, it did not make a whole lot of sense, so I [trimmed it down](https://github.com/gjohnson/up/blob/shutdown_reload/lib/up.js#L190) to only the first case.

To handle the [re-spawning](https://github.com/gjohnson/up/blob/shutdown_reload/lib/up.js#L119) without spinning into a cycical disaster, I simply bind to the `terminate` event in `UpServer` ctor. If the worker `exitCode` (which is set via `child_process.on('exit')`) is _1_, we check the `uptime` of the worker against the `uptimeThreshold`. If all is good, we respawn.
