### PR TITLE
Moved requires loop up so it precedes the loading of the server file.

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -2,7 +2,11 @@ var options = JSON.parse(process.argv[2])
   , requires = options.requires;
 
 /**
- * Run requires.
+ * Run requires before loading the server file.
+ * This ensures that any requires module that
+ * changes the behavior of the process or
+ * require() function (such as coffeescript)
+ * are present.
  */
 
 for (var i = 0, l = requires.length; i < l; i++) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,11 +1,20 @@
+var options = JSON.parse(process.argv[2])
+  , requires = options.requires;
+
+/**
+ * Run requires.
+ */
+
+for (var i = 0, l = requires.length; i < l; i++) {
+  require(requires[i]);
+}
+
 
 /**
  * Start server.
  */
 
-var options = JSON.parse(process.argv[2])
-  , server = require(options.file)
-  , requires = options.requires
+var server = require(options.file)
   , assumeReady = options.assumeReady
   , addr = null;
 
@@ -29,13 +38,6 @@ function ready() {
   });
 }
 
-/**
- * Run requires.
- */
-
-for (var i = 0, l = requires.length; i < l; i++) {
-  require(requires[i]);
-}
 
 /**
  * Listen.


### PR DESCRIPTION
I've changed worker.js so options.requires are require()'ed before the server file gets loaded. Currently running an app that uses Up with coffeescript directly doesn't work, this would allow child processes to load .coffee files (and more generally, feel the impact of any module that changes the behavior of require())

I don't think there would be any negative impact from this change, if there is let me know.

Thanks a bunch!
Chris
