### PR TITLE
Fixing reload to no longer send requests to old workers

### DIFF
--- a/lib/up.js
+++ b/lib/up.js
@@ -204,6 +204,7 @@ UpServer.prototype.spawnWorker = function (fn) {
         self.emit('spawn', w);
         break;
 
+      case 'terminating':
       case 'terminated':
         if (~self.spawning.indexOf(w)) {
           self.spawning.splice(self.spawning.indexOf(w), 1);

--- a/test/up.test.js
+++ b/test/up.test.js
@@ -127,14 +127,26 @@ describe('up', function () {
 
               srv.once('spawn', function () {
                 request.get('http://localhost:6002', function (res) {
-                  expect(res.body.pid).to.not.equal(pid1);
-                  pid1 = res.body.pid;
+                  var pid3 = res.body.pid;
+                  expect(pid3).to.not.equal(pid1);
+                  expect(pid3).to.not.equal(pid2);
 
                   request.get('http://localhost:6002', function (res) {
-                    expect(res.body.pid).to.not.equal(pid1);
-                    expect(res.body.pid).to.not.equal(pid2);
-                    expect(reloadFired).to.be(true);
-                    done();
+                    var pid4 = res.body.pid;
+                    expect(pid4).to.not.equal(pid1);
+                    expect(pid4).to.not.equal(pid2);
+                    expect(pid4).to.not.equal(pid3);
+
+                    request.get('http://localhost:6002', function (res) {
+                      // confirm that the initial workers are not used when the
+                      // server gets back to the start of the list
+                      var pid5 = res.body.pid;
+                      expect(pid5).to.not.equal(pid1);
+                      expect(pid5).to.not.equal(pid2);
+
+                      expect(reloadFired).to.be(true);
+                      done();
+                    });
                   });
                 });
               });


### PR DESCRIPTION
It looks like there was an issue with reloading introduced recently. Currently when the server reloads, old workers are still sent requests until they hit their timeout.

I updated the reload test to bring out the issue and added back the terminating case in `spawnWorker` to resolve it.
