### PR TITLE
Added support for the --require option to enable CoffeeScript (or other transcoders) when loading the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ when files change in the working directory.
   upon file changes.
 - Gracefully handles reloads with syntax errors during development.
 - Built on [distribute](http://github.com/learnboost/distribute).
+- Supports transcoders such as CoffeeScript.
 
 ## Setup
 
@@ -64,6 +65,7 @@ The `up` command accepts the following options:
 
   - Specifies a module to require from each worker.
   - Can be used multiple times.
+  - Transcoders such as CoffeeScript can be supported with `--require coffee-script`
 
 - `-n`/`--number`
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ when files change in the working directory.
   upon file changes.
 - Gracefully handles reloads with syntax errors during development.
 - Built on [distribute](http://github.com/learnboost/distribute).
-- Supports transcoders such as CoffeeScript.
+- Supports transpilers such as CoffeeScript.
 
 ## Setup
 
@@ -65,7 +65,7 @@ The `up` command accepts the following options:
 
   - Specifies a module to require from each worker.
   - Can be used multiple times.
-  - Transcoders such as CoffeeScript can be supported with `--require coffee-script`
+  - Tranpilers such as CoffeeScript can be supported with `--require coffee-script`
 
 - `-n`/`--number`
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The `up` command accepts the following options:
 
   - Specifies a module to require from each worker.
   - Can be used multiple times.
-  - Tranpilers such as CoffeeScript can be supported with `--require coffee-script`
+  - Tranpilers such as CoffeeScript can be supported with `--require|-r coffee-script`
 
 - `-n`/`--number`
 

--- a/bin/up
+++ b/bin/up
@@ -87,6 +87,9 @@ if ('/' != file[0]) file = process.cwd() + '/' + file;
 
 // verify we can require
 try {
+  for (var i = 0, l = requires.length; i < l; i++) {
+    require(requires[i]);
+  }
   server = require(file);
 } catch (e) {
   error('\n  Error requiring supplied module "%s".\n  %s\n'


### PR DESCRIPTION
Simply added code to `require` each of the `--require` options before calling `server = require(file)`
