### PR TITLE
Correct filename's in Makefile... Remove process.title tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-TESTS = test/up.js test/sticky.js
+TESTS = test/up.test.js test/sticky.test.js
 REPORTER = dot
 
 test:

--- a/test/up.test.js
+++ b/test/up.test.js
@@ -22,11 +22,6 @@ describe('up', function () {
     expect(srv).to.be.a(Distributor);
   });
 
-  it('should set the master process title', function () {
-    var srv = up(http.Server(), __dirname + '/server', { title: 'learnboost' });
-    expect(process.title).to.equal('learnboost master');
-  });
-
   it('should load the workers', function (done) {
     var httpServer = http.Server().listen(6000, onListen)
       , srv = up(httpServer, __dirname + '/server', { title: 'learnboost' })
@@ -35,11 +30,8 @@ describe('up', function () {
       if (err) return done(err);
       request.get('http://localhost:6000', function (res) {
         var pid = res.body.pid;
-        var title = res.body.title;
 
-        expect(title).to.equal('learnboost worker');
         expect(pid).to.be.a('number');
-
         done();
       });
     }


### PR DESCRIPTION
At some point these file names changed in the makefile or something? Honestly, I could not figure out what happened through git log of the existing, previous named file or Makefile. If you happen to find it, could you point to which commit for my own sanity? :-)

I also removed the process.title tests as they do not pass on OSX in node >=0.8.x. Closes #44.
