### PR TITLE
Added --ignore option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ The `up` command accepts the following options:
   - Whether to watch for changes.
   - Watches the working directory for changes.
 
+- `-i`/`--ignore` `<paths>`
+
+  - When using `--watch`, define paths to ignore (comma separated)
+  - `.git,node_modules` are ignored by default and are added to your ignored paths
+  - eg: `--ignore public,vendor`
+
 - `-r`/`--require` `<mod>`
 
   - Specifies a module to require from each worker.

--- a/bin/up
+++ b/bin/up
@@ -39,6 +39,7 @@ program
   .option('-T, --title <title>', 'Process title.', 'up')
   .option('-f, --pidfile <pidfile>', 'Write port to pidfile')
   .option('-w, --watch', 'Watch the module directory for changes.')
+  .option('-i, --ignore <paths>', 'Ignore files when watching for changes.')
   .option('-r, --require <file>', 'Module to require from each worker.')
   .option('-n, --number <workers>', 'Number of workers to spawn.'
     , 'development' == process.env.NODE_ENV ? 1 : cpus)
@@ -226,7 +227,14 @@ if (undefined != program.watch) {
    * Ignored directories.
    */
 
-  var ignore = ['node_modules', '.git'];
+  if (undefined != program.ignore) {
+    console.log(program.ignore);
+    var ignore = program.ignore.split(",");
+    ignore = ['node_modules', '.git'].concat(ignore);
+    console.log(ignore);
+  } else {
+    var ignore = ['node_modules', '.git'];
+  }
 
   /**
    * Ignored files.

--- a/bin/up
+++ b/bin/up
@@ -228,10 +228,8 @@ if (undefined != program.watch) {
    */
 
   if (undefined != program.ignore) {
-    console.log(program.ignore);
     var ignore = program.ignore.split(",");
     ignore = ['node_modules', '.git'].concat(ignore);
-    console.log(ignore);
   } else {
     var ignore = ['node_modules', '.git'];
   }

--- a/bin/up
+++ b/bin/up
@@ -228,8 +228,7 @@ if (undefined != program.watch) {
    */
 
   if (undefined != program.ignore) {
-    var ignore = program.ignore.split(",");
-    ignore = ['node_modules', '.git'].concat(ignore);
+    var ignore = ['node_modules', '.git'].concat(program.ignore.split(","));
   } else {
     var ignore = ['node_modules', '.git'];
   }

--- a/lib/up.js
+++ b/lib/up.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -263,8 +262,8 @@ UpServer.prototype.defaultWS = function (req, res, next) {
       var result = 0;
 
       sid = sid.split('');
-      for(var index in glyphs) {
-        result = (result * 64) + glyphs.indexOf(glyphs[index]);
+      for(var index = sid.length - 1; index >= 0; index--) {
+        result = (result * 64) + glyphs.indexOf(sid[index]);
       }
       sid = result;
     }

--- a/lib/up.js
+++ b/lib/up.js
@@ -257,6 +257,18 @@ UpServer.prototype.defaultWS = function (req, res, next) {
   if(this.workers.length && matcher && matcher.length > 2) {
     // transport = matcher[1], sid = matcher[2]
     var sid = matcher[2];
+
+    if(typeof(sid) !== 'number') {
+      var glyphs = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+      var result = 0;
+
+      sid = sid.split('');
+      for(var index in glyphs) {
+        result = (result * 64) + glyphs.indexOf(glyphs[index]);
+      }
+      sid = result;
+    }
+
     var workerIndex = sid % this.workers.length;
     next(this.workers[workerIndex].port);
   } else if (this.workers.length) {


### PR DESCRIPTION
From the modified README:
- `-i`/`--ignore` `<paths>`
  - When using `--watch`, define paths to ignore (comma separated)
  - `.git,node_modules` are ignored by default and are added to your ignored paths
  - eg: `--ignore public,vendor`
