### PR TITLE
Fixed a crash for Socket.io > 0.9.6 requests

### DIFF
--- a/lib/up.js
+++ b/lib/up.js
@@ -257,6 +257,18 @@ UpServer.prototype.defaultWS = function (req, res, next) {
   if(this.workers.length && matcher && matcher.length > 2) {
     // transport = matcher[1], sid = matcher[2]
     var sid = matcher[2];
+
+    if(typeof(sid) !== 'number') {
+      var glyphs = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+      var result = 0;
+
+      sid = sid.split('');
+      for(var index in glyphs) {
+        result = (result * 64) + glyphs.indexOf(glyphs[index]);
+      }
+      sid = result;
+    }
+
     var workerIndex = sid % this.workers.length;
     next(this.workers[workerIndex].port);
   } else if (this.workers.length) {


### PR DESCRIPTION
- workerIndex is NaN when sid is base64
  (Socket.io > 0.9.6)
- Fixes it by converting sid to a number
