### PR TITLE
Exponentially backed-off respawns with maximum attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ parameters:
   - `title`: (`String`): see `--title` above.
   - `assumeReady`: (`Boolean`): see Worker readiness below.
   - `keepAlive`: (`Boolean`): see `--keepalive` above.
+  - `backoffRespawns`: null to disable exponential backoff respawns.  -1 to disable maximum respawns, and any positive int to set a limit on attempted respawns
+  - `backoffDelay`: delay to first respawn attempt in milliseconds
+  - `backoffMaxDelay`: the maximum delay between respawn attempts in milliseconds
   - `minExpectedLifetime`: (`Number`|`String`): Number of ms a worker is
     expected to live. Don't auto-respawn if a worker dies earlier. Strings
     like `'10s'` are accepted. Defaults to `'20s'`.

--- a/examples/hello-world/up.js
+++ b/examples/hello-world/up.js
@@ -1,4 +1,4 @@
 
 var server = require('http').Server().listen(3000)
 
-require('../../up')(server, __dirname + '/server')
+require('../../../up')(server, __dirname + '/server')

--- a/lib/up.js
+++ b/lib/up.js
@@ -206,6 +206,12 @@ UpServer.prototype.spawnWorker = function (fn, dontrespawn) {
         self.workers.push(w);
         fn && fn(w.readyState);
         self.emit('spawn', w);
+        // wait until minExpectedLifetime has been reached so that failed starts can be restarted
+        setTimeout(function() { 
+          if (w.readyState != 'spawned') { 
+            self.emit('unsuccessful', w);
+          } 
+        }, self.minExpectedLifetime+1); 
         break;
 
       case 'terminating':
@@ -251,17 +257,17 @@ UpServer.prototype.respawnWorker = function () {
       })
     respawnBackoff.on('ready', function(number, delay) {
         self.spawnWorker(function(readyState) {
-          if (readyState != 'spawned') {
+          if (readyState == 'terminated') {
             self.emit('respawn');
             respawnBackoff.backoff();
           }
         }, true);
       })
-    respawnBackoff.on('error', function() {
-        self.emit('spawnerror');
-      });
+    respawnBackoff.on('fail', function() {
+      self.emit('respawnerror');
+    });
     if (self.backoffRespawns > 0) {
-      respawnBackoff.failAfter(self.backoffRespawns);
+      respawnBackoff.failAfter(self.backoffRespawns-1);
     }
     respawnBackoff.backoff();
   }

--- a/lib/up.js
+++ b/lib/up.js
@@ -85,7 +85,7 @@ function UpServer (server, file, opts) {
   this.keepAlive = opts.keepAlive || false;
   this.minExpectedLifetime = ms(opts.minExpectedLifetime != null ? opts.minExpectedLifetime : minExpectedLifetime);
   this.backoffRespawns = opts.backoffRespawns || null;
-  this.backoffDelay = opts.backoffDelay || 100;
+  this.backoffInitDelay = opts.backoffInitDelay || 100;
   this.backoffMaxDelay = opts.backoffMaxDelay || 10000;
   if (false !== opts.workerPingInterval) {
     this.workerPingInterval = ms(opts.workerPingInterval || '1m');
@@ -246,7 +246,7 @@ UpServer.prototype.respawnWorker = function () {
 
   if (self.backoffRespawns !== null) {
     var respawnBackoff = backoff.exponential({
-          initialDelay: self.backoffDelay
+          initialDelay: self.backoffInitDelay
         , maxDelay: self.backoffMaxDelay
       })
     respawnBackoff.on('ready', function(number, delay) {

--- a/lib/up.js
+++ b/lib/up.js
@@ -212,7 +212,7 @@ UpServer.prototype.spawnWorker = function (fn, dontrespawn) {
           if (w.readyState == 'terminating' || w.readyState == 'terminated') { 
             self.emit('unsuccessful', w);
           } 
-        }, self.minExpectedLifetime+1); 
+        }, self.minExpectedLifetime-1); 
         break;
 
       case 'terminating':
@@ -234,7 +234,7 @@ UpServer.prototype.spawnWorker = function (fn, dontrespawn) {
           }
           fn && fn(w.readyState);
         } 
-        else {
+        else if (previousState == 'spawning' && w.proc.exitCode > 0) {
           self.emit('unsuccessful', w);
         }
         self.emit('terminate', w);

--- a/lib/up.js
+++ b/lib/up.js
@@ -235,7 +235,13 @@ UpServer.prototype.spawnWorker = function (fn, dontrespawn) {
           fn && fn(w.readyState);
         } 
         else if (previousState == 'spawning' && w.proc.exitCode > 0) {
-          self.emit('unsuccessful', w);
+          if (self.minExpectedLifetime == 0 && self.keepAlive && (self.workers.length + self.spawning.length < self.numWorkers)) { // special case
+            debug('worker %s found dead. spawning 1 new worker', w.pid);
+            if (!dontrespawn) self.respawnWorker();
+          }
+          else {
+            self.emit('unsuccessful', w);
+          }
         }
         self.emit('terminate', w);
         break;

--- a/lib/up.js
+++ b/lib/up.js
@@ -261,12 +261,12 @@ UpServer.prototype.respawnWorker = function () {
         self.emit('spawnerror');
       });
     if (self.backoffRespawns > 0) {
-      respawnBackoff.failAfter(self.maxRespawns);
+      respawnBackoff.failAfter(self.backoffRespawns);
     }
     respawnBackoff.backoff();
   }
   else {
-    self.spawnWorker();
+    self.spawnWorker(null, true);
   }
 };
 

--- a/lib/up.js
+++ b/lib/up.js
@@ -194,7 +194,8 @@ UpServer.prototype.spawnWorkers = function (n) {
 
 UpServer.prototype.spawnWorker = function (fn, dontrespawn) {
   var w = new Worker(this)
-    , self = this;
+    , self = this
+    , previousState = w.readyState;
 
   // keep track that we're spawning
   this.spawning.push(w);
@@ -208,7 +209,7 @@ UpServer.prototype.spawnWorker = function (fn, dontrespawn) {
         self.emit('spawn', w);
         // wait until minExpectedLifetime has been reached so that failed starts can be restarted
         setTimeout(function() { 
-          if (w.readyState != 'spawned') { 
+          if (w.readyState == 'terminating' || w.readyState == 'terminated') { 
             self.emit('unsuccessful', w);
           } 
         }, self.minExpectedLifetime+1); 
@@ -223,7 +224,7 @@ UpServer.prototype.spawnWorker = function (fn, dontrespawn) {
           self.workers.splice(self.workers.indexOf(w), 1);
           self.lastIndex = -1;
           if (self.keepAlive && (self.workers.length + self.spawning.length < self.numWorkers)) {
-            if (new Date().getTime() - w.birthtime < self.minExpectedLifetime) {
+            if (w.uptime() < self.minExpectedLifetime) {
               debug('worker %s found dead at a too young an age. won\'t respawn new worker', w.pid);
             }
             else {
@@ -232,10 +233,14 @@ UpServer.prototype.spawnWorker = function (fn, dontrespawn) {
             }
           }
           fn && fn(w.readyState);
+        } 
+        else {
+          self.emit('unsuccessful', w);
         }
         self.emit('terminate', w);
         break;
     }
+    previousState = w.readyState;
   });
 };
 
@@ -420,6 +425,16 @@ Worker.prototype.shutdown = function () {
     this.readyState = 'terminating';
     this.emit('stateChange');
   }
+};
+
+/**
+ * Uptime of current worker
+ *
+ * @api public
+ */
+
+Worker.prototype.uptime = function() {
+  return new Date().getTime() - this.birthtime;
 };
 
 /**

--- a/lib/up.js
+++ b/lib/up.js
@@ -84,7 +84,7 @@ function UpServer (server, file, opts) {
   this.assumeReady = opts.assumeReady === undefined ? true : !!opts.assumeReady;
   this.keepAlive = opts.keepAlive || false;
   this.minExpectedLifetime = ms(opts.minExpectedLifetime != null ? opts.minExpectedLifetime : minExpectedLifetime);
-  this.backoffRespawns = opts.backoffRespawns || -1;
+  this.backoffRespawns = opts.backoffRespawns || null;
   this.backoffDelay = opts.backoffDelay || 100;
   this.backoffMaxDelay = opts.backoffMaxDelay || 10000;
   if (false !== opts.workerPingInterval) {

--- a/lib/up.js
+++ b/lib/up.js
@@ -7,6 +7,7 @@ var fork = require('child_process').fork
   , eq = require('eq')
   , os = require('os')
   , ms = require('ms')
+  , backoff = require('backoff')
   , env = process.env.NODE_ENV
   , Distributor = require('distribute')
   , EventEmitter = require('events').EventEmitter
@@ -83,6 +84,9 @@ function UpServer (server, file, opts) {
   this.assumeReady = opts.assumeReady === undefined ? true : !!opts.assumeReady;
   this.keepAlive = opts.keepAlive || false;
   this.minExpectedLifetime = ms(opts.minExpectedLifetime != null ? opts.minExpectedLifetime : minExpectedLifetime);
+  this.backoffRespawns = opts.backoffRespawns || -1;
+  this.backoffDelay = opts.backoffDelay || 100;
+  this.backoffMaxDelay = opts.backoffMaxDelay || 10000;
   if (false !== opts.workerPingInterval) {
     this.workerPingInterval = ms(opts.workerPingInterval || '1m');
   }
@@ -188,9 +192,9 @@ UpServer.prototype.spawnWorkers = function (n) {
  * @api public
  */
 
-UpServer.prototype.spawnWorker = function (fn) {
+UpServer.prototype.spawnWorker = function (fn, dontrespawn) {
   var w = new Worker(this)
-    , self = this
+    , self = this;
 
   // keep track that we're spawning
   this.spawning.push(w);
@@ -200,6 +204,7 @@ UpServer.prototype.spawnWorker = function (fn) {
       case 'spawned':
         self.spawning.splice(self.spawning.indexOf(w), 1);
         self.workers.push(w);
+        fn && fn(w.readyState);
         self.emit('spawn', w);
         break;
 
@@ -213,18 +218,56 @@ UpServer.prototype.spawnWorker = function (fn) {
           self.lastIndex = -1;
           if (self.keepAlive && (self.workers.length + self.spawning.length < self.numWorkers)) {
             if (new Date().getTime() - w.birthtime < self.minExpectedLifetime) {
-              debug('worker %s found dead at a too young age. won\'t respawn new worker', w.pid);
+              debug('worker %s found dead at a too young an age. won\'t respawn new worker', w.pid);
             }
             else {
               debug('worker %s found dead. spawning 1 new worker', w.pid);
-              self.spawnWorker();
+              if (!dontrespawn) self.respawnWorker();
             }
           }
+          fn && fn(w.readyState);
         }
-        self.emit('terminate', w)
+        self.emit('terminate', w);
         break;
     }
   });
+};
+
+/**
+ * Spawns a worker that binds to an available port.
+ *
+ * @api private
+ */
+
+UpServer.prototype.respawnWorker = function () {
+  var self = this;
+
+  self.emit('respawn');
+
+  if (self.backoffRespawns !== null) {
+    var respawnBackoff = backoff.exponential({
+          initialDelay: self.backoffDelay
+        , maxDelay: self.backoffMaxDelay
+      })
+    respawnBackoff.on('ready', function(number, delay) {
+        self.spawnWorker(function(readyState) {
+          if (readyState != 'spawned') {
+            self.emit('respawn');
+            respawnBackoff.backoff();
+          }
+        }, true);
+      })
+    respawnBackoff.on('error', function() {
+        self.emit('spawnerror');
+      });
+    if (self.backoffRespawns > 0) {
+      respawnBackoff.failAfter(self.maxRespawns);
+    }
+    respawnBackoff.backoff();
+  }
+  else {
+    self.spawnWorker();
+  }
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
       , "ms": "0.1.0"
       , "debug": "0.1.0"
       , "commander": "0.6.1"
+      , "backoff": "2.0.0"
       , "distribute": "0.1.4"
     }
   , "devDependencies": {

--- a/test/child-backoff.js
+++ b/test/child-backoff.js
@@ -1,0 +1,4 @@
+
+var httpServer = require('http').Server()
+  , up = require('../lib/up')(httpServer, __dirname + '/child-server-backoff'
+      , { workerPingInterval: '15ms', numWorkers: 1, keepAlive:true, minExpectedLifetime:0, backoffRespawns:-1, backoffInitDelay:10, backoffMaxDelay:1000 })

--- a/test/child-server-backoff.js
+++ b/test/child-server-backoff.js
@@ -1,0 +1,6 @@
+
+var client = require('net').connect(7003, function () {
+  client.write(String(process.pid));
+});
+
+module.exports = require('http').Server()

--- a/test/server-asyncfail.js
+++ b/test/server-asyncfail.js
@@ -1,0 +1,3 @@
+var server = require('./server');
+module.exports = server;
+setTimeout(function() { process.exit(1); }, 100);

--- a/test/server-fail.js
+++ b/test/server-fail.js
@@ -1,2 +1,2 @@
 
-throw new Error('I\'m just one big pile of fail');
+process.exit(1);

--- a/test/server-fail.js
+++ b/test/server-fail.js
@@ -1,0 +1,2 @@
+
+throw new Error('I\'m just one big pile of fail');

--- a/test/server.js
+++ b/test/server.js
@@ -9,7 +9,7 @@ var express = require('express')
  * Initialize server
  */
 
-var app = express.createServer();
+var app = express();
 
 /**
  * Default route.

--- a/test/up.backoff.test.js
+++ b/test/up.backoff.test.js
@@ -373,4 +373,29 @@ describe('up', function () {
     });
   });
 
+  it('should work emit unsuccessful events if first round of workers fail before they should', function (done) {
+    var httpServer = http.Server().listen()
+      , opts = { numWorkers: 1, keepAlive: true, minExpectedLifetime: '50', backoffRespawns:-1, backoffInitDelay:10, backoffMaxDelay:50 }
+      , srv = up(httpServer, __dirname + '/server-fail', opts)
+      , orgPid = null;
+    srv.once('spawn', function () {
+      expect(srv.workers).to.have.length(1);
+      orgPid = srv.workers[0].pid
+      setTimeout(function () {
+        process.kill(orgPid, 'SIGKILL');
+        setTimeout(function ()  {
+          expect(srv.workers).to.have.length(1);
+          expect(srv.workers[0].pid).to.not.equal(orgPid);
+          done();
+        }, 300)  // give it time to die and respawn
+      }, 75)  // greater than minExpectedLifetime
+    });
+    srv.on('respawn', function() {
+      throw new Error('Respawn should not be hit because worker fails too young');
+    });
+    srv.on('unsuccessful', function() {
+      done();
+    });
+  });
+
 });

--- a/test/up.backoff.test.js
+++ b/test/up.backoff.test.js
@@ -1,0 +1,376 @@
+
+/**
+ * Test dependencies
+ */
+
+var up = require('../lib/up')
+  , net = require('net')
+  , http = require('http')
+  , expect = require('expect.js')
+  , request = require('superagent')
+  , child_process = require('child_process')
+  , Distributor = require('distribute')
+
+if (process.platform == 'darwin') {
+  console.log('Warning: process.title is known not to work on mac.  These tests will be skipped.  See https://github.com/joyent/node/issues/3687');
+}
+
+/**
+ * Suite.
+ */
+
+describe('up', function () {
+
+  it('should load the workers with backoff enabled', function (done) {
+    var httpServer = http.Server().listen(7000, onListen)
+      , srv = up(httpServer, __dirname + '/server', { title: 'learnboost', keepAlive:true, minExpectedLifetime:0, backoffRespawns:-1, backoffInitDelay:10, backoffMaxDelay:1000 })
+
+    function onListen (err) {
+      if (err) return done(err);
+      request.get('http://localhost:7000', function (res) {
+        var pid = res.body.pid;
+        var title = res.body.title;
+
+        if (process.platform != 'darwin') {
+          expect(title).to.equal('learnboost worker');
+        }
+        expect(pid).to.be.a('number');
+
+        done();
+      });
+    }
+  });
+
+  it('should round-robin the workers with backoff enabled', function (done) {
+    var httpServer = http.Server().listen(7001, onListen)
+      , srv = up(httpServer, __dirname + '/server', { numWorkers: 2, keepAlive:true, minExpectedLifetime:0, backoffRespawns:-1, backoffInitDelay:10, backoffMaxDelay:1000 })
+
+    function onListen (err) {
+      if (err) return done(err);
+
+      srv.on('spawn', function () {
+        // count workers
+        if (2 != srv.workers.length) return;
+
+        request.get('http://localhost:7001', function (res) {
+          var pid1 = res.body.pid;
+          expect(pid1).to.be.a('number');
+
+          request.get('http://localhost:7001', function (res) {
+            var pid2 = res.body.pid;
+            expect(pid2).to.be.a('number');
+            expect(pid2).to.not.equal(pid1);
+
+            request.get('http://localhost:7001', function (res) {
+              expect(res.body.pid).to.equal(pid1);
+
+              request.get('http://localhost:7001', function (res) {
+                expect(res.body.pid).to.equal(pid2);
+                done();
+              });
+            });
+          });
+        });
+      });
+    }
+  });
+
+  it('should expose ports and procs as public api with backoff enabled', function (done) {
+    var httpServer = http.Server().listen()
+      , srv = up(httpServer, __dirname + '/server', { numWorkers: 2, keepAlive:true, minExpectedLifetime:0, backoffRespawns:-1, backoffInitDelay:10, backoffMaxDelay:1000 })
+
+    srv.once('spawn', function () {
+      expect(srv.workers).to.have.length(1);
+      done();
+    });
+  });
+
+  it('should reload workers with backoff enabled', function (done) {
+    var httpServer = http.Server().listen(7002, onListen)
+      , srv = up(httpServer, __dirname + '/server', { numWorkers: 2, keepAlive:true, minExpectedLifetime:0, backoffRespawns:-1, backoffInitDelay:10, backoffMaxDelay:1000 })
+      , reloadFired = false
+
+    function onListen (err) {
+      if (err) return done(err);
+
+      srv.on('spawn', onSpawn);
+
+      function onSpawn () {
+        // count workers
+        if (2 == srv.workers.length) {
+          // prevent race conditions with reload spawn events
+          srv.removeListener('spawn', onSpawn);
+        } else {
+          return;
+        }
+
+        request.get('http://localhost:7002', function (res) {
+          var pid1 = res.body.pid;
+          expect(pid1).to.be.a('number');
+
+          request.get('http://localhost:7002', function (res) {
+            var pid2 = res.body.pid;
+            expect(pid2).to.be.a('number');
+            expect(pid2).to.not.equal(pid1);
+
+            srv.once('reload', function () {
+              reloadFired = true;
+            });
+
+            srv.reload(function () {
+              // callback fires upon 1 spawning, so we set up another
+              // listener for the remaining worker
+
+              srv.once('spawn', function () {
+                request.get('http://localhost:7002', function (res) {
+                  var pid3 = res.body.pid;
+                  expect(pid3).to.not.equal(pid1);
+                  expect(pid3).to.not.equal(pid2);
+
+                  request.get('http://localhost:7002', function (res) {
+                    var pid4 = res.body.pid;
+                    expect(pid4).to.not.equal(pid1);
+                    expect(pid4).to.not.equal(pid2);
+                    expect(pid4).to.not.equal(pid3);
+
+                    request.get('http://localhost:7002', function (res) {
+                      // confirm that the initial workers are not used when the
+                      // server gets back to the start of the list
+                      var pid5 = res.body.pid;
+                      expect(pid5).to.not.equal(pid1);
+                      expect(pid5).to.not.equal(pid2);
+
+                      expect(reloadFired).to.be(true);
+                      done();
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      }
+    }
+  });
+
+  it('should suicide workers if master dies with backoff enabled', function (done) {
+    // utility to check whether a pid is alive
+    // https://raw.github.com/visionmedia/monit.js/master/lib/utils.js
+    function alive (pid) {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch (err) {
+        return false;
+      }
+    };
+
+    var proc;
+
+    // the spawn process will start an up server with 1 worker and
+    // will send us the pid over a net channel
+    net.createServer(function (conn) {
+      conn.setEncoding('utf8');
+      conn.on('data', function (pid) {
+        expect(alive(pid)).to.be(true);
+
+        // kill master
+        switch (process.platform) {
+          case 'win32':
+            proc.kill();
+            break;
+          default:
+            proc.kill('SIGHUP');
+        }
+
+        // since the ping interval is set to 15ms, we try in 30
+        setTimeout(function () {
+          expect(alive(pid)).to.be(false);
+          done();
+        }, 30);
+      });
+    }).listen(7003, onListen);
+
+    function onListen () {
+      // create a child process (master) we'll kill later
+      proc = child_process.spawn('node', [__dirname + '/child-backoff.js']);
+    }
+  });
+
+  function testAssumeReady(done, async) {
+    var httpServer = http.Server().listen()
+      , srv = up(httpServer, __dirname + '/ready', { numWorkers: 1, assumeReady: !async, keepAlive:true, minExpectedLifetime:0, backoffRespawns:-1, backoffInitDelay:10, backoffMaxDelay:1000 })
+      , worker, ready = false;
+
+    expect(srv.spawning.length).to.be(1);
+    worker = srv.spawning[0];
+    worker.proc.on('message', function(msg){
+      if (msg.type !== 'test, im ready') return;
+      ready = true;
+    });
+    srv.on('spawn', function () {
+      expect(ready).to.be(async);
+      done();
+    });
+  }
+  it('should support asynchronous loading workers with backoff enabled', function (done) {
+    testAssumeReady(done, true);
+  });
+  it('should support synchronous loading workers by default with backoff enabled', function (done) {
+    testAssumeReady(done, false);
+  });
+
+  it('should respawn a worker a maximum number of times with backoff enabled and no minimum life set', function (done) {
+    var httpServer = http.Server().listen()
+      , opts = { numWorkers: 1, keepAlive: true, minExpectedLifetime: 0, backoffRespawns:3, backoffInitDelay:10, backoffMaxDelay:50 }
+      , srv = up(httpServer, __dirname + '/server', opts)
+      , orgPid = null
+      , respawnCount = 0
+      , unsuccessfulEmitted = false;
+    srv.on('spawn', function (w) {
+      respawnCount++;
+      expect(srv.workers).to.have.length(1);    
+      expect(srv.workers[0].pid).to.not.equal(orgPid);
+      orgPid = srv.workers[0].pid
+      process.nextTick(function () {
+        expect(srv.workers[0].pid).to.equal(orgPid);
+        expect(srv.workers).to.have.length(1);
+        process.kill(orgPid, 'SIGKILL');
+        if (respawnCount > opts.backoffRespawns) {
+          throw new Error('Respawned more than wanted');
+        }
+      });
+    });
+    srv.on('terminate', function(w) {
+      expect(w.pid).to.equal(orgPid);
+      expect(srv.workers).to.have.length(0);
+    });
+    srv.on('unsuccessful', function(w) {
+      throw new Error('All respawns should complete successfully');
+    });
+    srv.on('respawn', function() {
+      expect(srv.workers).to.have.length(0);
+    });
+    srv.on('respawnerror', function() {
+      done();
+    });
+  });
+
+  it('should respawn a worker a maximum number of times with backoff enabled and minimum life set', function (done) {
+    var httpServer = http.Server().listen()
+      , opts = { numWorkers: 1, keepAlive: true, minExpectedLifetime: 100, backoffRespawns:3, backoffInitDelay:10, backoffMaxDelay:50 }
+      , srv = up(httpServer, __dirname + '/server', opts)
+      , orgPid = null
+      , respawnCount = 0
+      , unsuccessfulEmitted = false;
+    srv.on('spawn', function (w) {
+      respawnCount++;
+      expect(srv.workers).to.have.length(1);    
+      expect(srv.workers[0].pid).to.not.equal(orgPid);
+      orgPid = srv.workers[0].pid
+      process.nextTick(function () {
+        expect(srv.workers[0].pid).to.equal(orgPid);
+        expect(srv.workers).to.have.length(1);
+        process.kill(orgPid, 'SIGKILL');
+        if (respawnCount > opts.backoffRespawns) {
+          throw new Error('Respawned more than wanted');
+        }
+      });
+    });
+    srv.on('terminate', function(w) {
+      expect(w.pid).to.equal(orgPid);
+      expect(srv.workers).to.have.length(0);
+    });
+    srv.on('unsuccessful', function(w) {
+      expect(w.pid).to.equal(orgPid);
+      unsuccessfulEmitted = true;
+    });
+    srv.on('respawn', function() {
+      expect(srv.workers).to.have.length(0);
+    });
+    srv.on('respawnerror', function() {
+      expect(unsuccessfulEmitted).to.equal(true);
+      done();
+    });
+  });
+
+  it('should respawn a worker indefinitely when it dies with backoff enabled and respawn limit disabled and no minimum life', function (done) {
+    var httpServer = http.Server().listen()
+      , opts = { numWorkers: 1, keepAlive: true, minExpectedLifetime: '0', backoffRespawns:-1, backoffInitDelay:10, backoffMaxDelay:50 }
+      , srv = up(httpServer, __dirname + '/server', opts)
+      , orgPid = null
+      , respawnCount = 0
+      , respawnsSatisfied = 10;
+    srv.on('spawn', function (w) {
+      respawnCount++;
+      expect(srv.workers).to.have.length(1);    
+      expect(srv.workers[0].pid).to.not.equal(orgPid);
+      orgPid = srv.workers[0].pid
+      process.nextTick(function () {
+        expect(srv.workers[0].pid).to.equal(orgPid);
+        expect(srv.workers).to.have.length(1);    
+        if (respawnCount >= respawnsSatisfied) {
+          done();
+        }
+        else { // this. otherwise it will keep restarting indefinitely and lead to done called twice errors
+          process.kill(orgPid, 'SIGKILL');
+        }
+      });
+    });
+    srv.on('terminate', function(w) {
+      expect(w.pid).to.equal(orgPid);
+      expect(srv.workers).to.have.length(0);
+    });
+    srv.on('unsuccessful', function(w) {
+      throw new Error('All respawns should complete successfully');
+    });
+    srv.on('respawn', function() {
+      expect(srv.workers).to.have.length(0);
+    });
+    srv.on('respawnerror', function() {
+      throw new Error('respawn error should not occur with backoffRespawn limit disabled');
+    });
+  });
+
+  it('should respawn a worker indefinitely when it dies with backoff enabled and respawn limit disabled and minimum life set', function (done) {
+    var httpServer = http.Server().listen()
+      , opts = { numWorkers: 1, keepAlive: true, minExpectedLifetime: 100, backoffRespawns:-1, backoffInitDelay:10, backoffMaxDelay:50 }
+      , srv = up(httpServer, __dirname + '/server', opts)
+      , orgPid = null
+      , respawnCount = 0
+      , respawnsSatisfied = 5
+      , unsuccessfulEmitted = false;
+    srv.on('spawn', function (w) {
+      respawnCount++;
+      expect(srv.workers).to.have.length(1);    
+      expect(srv.workers[0].pid).to.not.equal(orgPid);
+      orgPid = srv.workers[0].pid
+      process.nextTick(function () {
+        expect(srv.workers[0].pid).to.equal(orgPid);
+        expect(srv.workers).to.have.length(1);
+        if (respawnCount >= respawnsSatisfied) {
+          expect(unsuccessfulEmitted).to.equal(true);
+          done();
+        }
+        else { // this. otherwise it will keep restarting indefinitely and lead to done called twice errors
+          process.kill(orgPid, 'SIGKILL');
+        }
+      });
+    });
+    srv.on('terminate', function(w) {
+      expect(w.pid).to.equal(orgPid);
+      expect(srv.workers).to.have.length(0);
+    });
+    srv.on('unsuccessful', function(w) {
+      expect(w.pid).to.equal(orgPid);
+      unsuccessfulEmitted = true;
+    });
+    srv.on('respawn', function() {
+      expect(srv.workers).to.have.length(0);
+    });
+    srv.on('respawnerror', function() {
+      throw new Error('respawn error should not occur with backoffRespawn limit disabled');
+    });
+  });
+
+});

--- a/test/up.backoff.test.js
+++ b/test/up.backoff.test.js
@@ -413,4 +413,30 @@ describe('up', function () {
     });
   });
 
+  it('should not emit unsuccessful events and workers should respawn if min lifetime is 0 immediate with backoff', function (done) {
+    var httpServer = http.Server().listen()
+      , opts = { numWorkers: 1, keepAlive: true, minExpectedLifetime: '0', backoffRespawns:-1, backoffInitDelay:10, backoffMaxDelay:50 }
+      , srv = up(httpServer, __dirname + '/server-fail', opts)
+      , orgPid = null;
+    srv.once('respawn', function() {
+      setTimeout(function() { done(); }, 500); // give everything time to occur
+    });
+    srv.on('unsuccessful', function() {
+      throw new Error('Should not have emitted unsuccessful');
+    });
+  });
+
+  it('should not emit unsuccessful events and workers should respawn if min lifetime is 0 async with backoff', function (done) {
+    var httpServer = http.Server().listen()
+      , opts = { numWorkers: 1, keepAlive: true, minExpectedLifetime: '0', backoffRespawns:-1, backoffInitDelay:10, backoffMaxDelay:50 }
+      , srv = up(httpServer, __dirname + '/server-asyncfail', opts)
+      , orgPid = null;
+    srv.once('respawn', function() {
+      setTimeout(function() { done(); }, 500); // give everything time to occur
+    });
+    srv.on('unsuccessful', function() {
+      throw new Error('Should not have emitted unsuccessful');
+    });
+  });
+
 });

--- a/test/up.backoff.test.js
+++ b/test/up.backoff.test.js
@@ -373,28 +373,43 @@ describe('up', function () {
     });
   });
 
-  it('should work emit unsuccessful events if first round of workers fail before they should', function (done) {
+
+  it('should emit unsuccessful events and not respawn if first round of workers fails immediately with backoff', function (done) {
     var httpServer = http.Server().listen()
       , opts = { numWorkers: 1, keepAlive: true, minExpectedLifetime: '50', backoffRespawns:-1, backoffInitDelay:10, backoffMaxDelay:50 }
       , srv = up(httpServer, __dirname + '/server-fail', opts)
       , orgPid = null;
-    srv.once('spawn', function () {
-      expect(srv.workers).to.have.length(1);
-      orgPid = srv.workers[0].pid
-      setTimeout(function () {
-        process.kill(orgPid, 'SIGKILL');
-        setTimeout(function ()  {
-          expect(srv.workers).to.have.length(1);
-          expect(srv.workers[0].pid).to.not.equal(orgPid);
-          done();
-        }, 300)  // give it time to die and respawn
-      }, 75)  // greater than minExpectedLifetime
-    });
     srv.on('respawn', function() {
       throw new Error('Respawn should not be hit because worker fails too young');
     });
     srv.on('unsuccessful', function() {
-      done();
+      setTimeout(function() { done(); }, 500); // give everything time to occur
+    });
+  });
+
+  it('should emit unsuccessful events and not respawn if first round of workers fails asynchronously with backoff', function (done) {
+    var httpServer = http.Server().listen()
+      , opts = { numWorkers: 1, keepAlive: true, minExpectedLifetime: '300', backoffRespawns:-1, backoffInitDelay:10, backoffMaxDelay:50 } // minExpectedLifetime longer thatn asyncfail delay
+      , srv = up(httpServer, __dirname + '/server-asyncfail', opts)
+      , orgPid = null;
+    srv.on('respawn', function() {
+      throw new Error('Respawn should not be hit because worker fails too young');
+    });
+    srv.on('unsuccessful', function() {
+      setTimeout(function() { done(); }, 500); // give everything time to occur
+    });
+  });
+
+  it('should not emit unsuccessful events and respawn worker if first round of workers fails after min lifetime met with backoff', function (done) {
+    var httpServer = http.Server().listen()
+      , opts = { numWorkers: 1, keepAlive: true, minExpectedLifetime: '50', backoffRespawns:-1, backoffInitDelay:10, backoffMaxDelay:50 }
+      , srv = up(httpServer, __dirname + '/server-asyncfail', opts)
+      , orgPid = null;
+    srv.once('respawn', function() {
+      setTimeout(function() { done(); }, 500); // give everything time to occur
+    });
+    srv.on('unsuccessful', function() {
+      throw new Error('Should not have emitted unsuccessful');
     });
   });
 

--- a/test/up.test.js
+++ b/test/up.test.js
@@ -293,4 +293,30 @@ describe('up', function () {
     });
   });
 
+  it('should not emit unsuccessful events and workers should be respawn if min lifetime is 0 immediate', function (done) {
+    var httpServer = http.Server().listen()
+      , opts = { numWorkers: 1, keepAlive: true, minExpectedLifetime: '0' }
+      , srv = up(httpServer, __dirname + '/server-fail', opts)
+      , orgPid = null;
+    srv.on('respawn', function() {
+      setTimeout(function() { done(); }, 500); // give everything time to occur
+    });
+    srv.on('unsuccessful', function() {
+      throw new Error('Should not have emitted unsuccessful');
+    });
+  });
+
+  it('should not emit unsuccessful events and workers should be respawn if min lifetime is 0 async', function (done) {
+    var httpServer = http.Server().listen()
+      , opts = { numWorkers: 1, keepAlive: true, minExpectedLifetime: '0' }
+      , srv = up(httpServer, __dirname + '/server-asyncfail', opts)
+      , orgPid = null;
+    srv.on('respawn', function() {
+      setTimeout(function() { done(); }, 500); // give everything time to occur
+    });
+    srv.on('unsuccessful', function() {
+      throw new Error('Should not have emitted unsuccessful');
+    });
+  });
+
 });

--- a/test/up.test.js
+++ b/test/up.test.js
@@ -251,4 +251,29 @@ describe('up', function () {
     });
   });
 
+  it('should work emit unsuccessful events if first round of workers fail before they should', function (done) {
+    var httpServer = http.Server().listen()
+      , opts = { numWorkers: 1, keepAlive: true, minExpectedLifetime: '50' }
+      , srv = up(httpServer, __dirname + '/server-fail', opts)
+      , orgPid = null;
+    srv.once('spawn', function () {
+      expect(srv.workers).to.have.length(1);
+      orgPid = srv.workers[0].pid
+      setTimeout(function () {
+        process.kill(orgPid, 'SIGKILL');
+        setTimeout(function ()  {
+          expect(srv.workers).to.have.length(1);
+          expect(srv.workers[0].pid).to.not.equal(orgPid);
+          done();
+        }, 300)  // give it time to die and respawn
+      }, 75)  // greater than minExpectedLifetime
+    });
+    srv.on('respawn', function() {
+      throw new Error('Respawn should not be hit because worker fails too young');
+    });
+    srv.on('unsuccessful', function() {
+      done();
+    });
+  });
+
 });

--- a/test/up.test.js
+++ b/test/up.test.js
@@ -11,6 +11,10 @@ var up = require('../lib/up')
   , child_process = require('child_process')
   , Distributor = require('distribute')
 
+if (process.platform == 'darwin') {
+  console.log('Warning: process.title is known not to work on mac.  These tests will be skipped.  See https://github.com/joyent/node/issues/3687');
+}
+
 /**
  * Suite.
  */
@@ -22,10 +26,12 @@ describe('up', function () {
     expect(srv).to.be.a(Distributor);
   });
 
-  it('should set the master process title', function () {
-    var srv = up(http.Server(), __dirname + '/server', { title: 'learnboost' });
-    expect(process.title).to.equal('learnboost master');
-  });
+  if (process.platform != 'darwin') {
+    it('should set the master process title', function () {
+      var srv = up(http.Server(), __dirname + '/server', { title: 'learnboost' });
+      expect(process.title).to.equal('learnboost master');
+    });
+  }
 
   it('should load the workers', function (done) {
     var httpServer = http.Server().listen(6000, onListen)
@@ -37,7 +43,9 @@ describe('up', function () {
         var pid = res.body.pid;
         var title = res.body.title;
 
-        expect(title).to.equal('learnboost worker');
+        if (process.platform != 'darwin') {
+          expect(title).to.equal('learnboost worker');
+        }
         expect(pid).to.be.a('number');
 
         done();

--- a/test/up.test.js
+++ b/test/up.test.js
@@ -249,6 +249,9 @@ describe('up', function () {
         }, 300)  // give it time to die and respawn
       }, 75)  // greater than minExpectedLifetime
     });
+    srv.on('unsuccessful', function() {
+      throw new Error('Workers dying naturally should not emit unsuccessful');
+    });
   });
 
   it('should emit unsuccessful events and not respawn if first round of workers fails immediately', function (done) {


### PR DESCRIPTION
I find this useful when used in concert with minExpectedLifetime: '0s'

Adds 3 new options:
-backoffRespawns: null to disable; -1 to enable with no max. attempts; positive sets maximum attempts
-backoffDelay: node-backoff "initialDelay" option in milli
-backoffMaxDelay: node-backoff ""maxDelay" option in milli

Relies on node-backoff for the backoff implementation. 

Sorry... no tests =/  
